### PR TITLE
fix: corrige erro ao atribuir exercícios a pacientes

### DIFF
--- a/src/features/therapist/PatientModal/AssignTab.jsx
+++ b/src/features/therapist/PatientModal/AssignTab.jsx
@@ -67,7 +67,7 @@ export default function AssignTab({ patient, session, exercises, assignments, go
 
         // Clona o exercício global na tabela do terapeuta
         if (isGlobal) {
-          const newId = "ex_" + Date.now() + Math.random().toString(36).slice(2, 6);
+          const newId = crypto.randomUUID();
           await db.insert(
             "exercises",
             {
@@ -86,16 +86,16 @@ export default function AssignTab({ patient, session, exercises, assignments, go
         }
 
         if (isGlobal || !existingIds.includes(finalExId)) {
-          // ⚠️  Não enviamos therapist_id aqui — a coluna não existe em assignments
           const inserted = await db.insert(
             "assignments",
             {
-              id:          "a" + Date.now() + Math.random().toString(36).slice(2, 5),
-              patient_id:  patient.id,
-              exercise_id: finalExId,
-              assigned_at: new Date().toISOString(),
-              status:      "pending",
-              due_date:    dueDates[exId] || null,
+              id:           crypto.randomUUID(),
+              patient_id:   patient.id,
+              exercise_id:  finalExId,
+              therapist_id: session.id,
+              assigned_at:  new Date().toISOString(),
+              status:       "pending",
+              due_date:     dueDates[exId] || null,
             },
             session.access_token
           );
@@ -114,7 +114,7 @@ export default function AssignTab({ patient, session, exercises, assignments, go
         await db.insert(
           "goals",
           {
-            id:            "g" + Date.now(),
+            id:            crypto.randomUUID(),
             patient_id:    patient.id,
             therapist_id:  session.id,
             weekly_target: weeklyGoal,
@@ -178,6 +178,7 @@ export default function AssignTab({ patient, session, exercises, assignments, go
                     >
                       ✕
                     </button>
+
                   </div>
                 );
               }


### PR DESCRIPTION
## Problema

Ao tentar atribuir exercícios a pacientes, ocorria erro na base de dados por dois motivos:

### 1. IDs com formato inválido para UUID
O Supabase espera colunas `id` do tipo `UUID`. O código gerava IDs como `"a1742075234abc"`, `"ex_17420..."` e `"g17420..."`, que violam a constraint de tipo.

**Antes:**
```js
id: "a" + Date.now() + Math.random().toString(36).slice(2, 5)  // ❌
id: "ex_" + Date.now() + Math.random().toString(36).slice(2, 6) // ❌
id: "g" + Date.now()  // ❌
```

**Depois:**
```js
id: crypto.randomUUID()  // ✅ UUID válido nativo do browser
```

### 2. `therapist_id` ausente no INSERT de `assignments`
A política RLS do Supabase em `assignments` usa `auth.uid() = therapist_id` para autorizar o INSERT. O campo não era enviado, então o Supabase bloqueava a operação.

**Adicionado:**
```js
therapist_id: session.id,  // ✅ agora incluído
```

## Arquivos alterados
- `src/features/therapist/PatientModal/AssignTab.jsx`

## O que NÃO foi alterado
- Nenhuma lógica de UI, CSS, remoção de assignments, filtros ou abas foi modificada.
- O comportamento do componente é 100% idêntico ao original — só os IDs e o campo `therapist_id` foram corrigidos.