### PR TITLE
feat: responsive improvements — full breakpoint coverage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -156,6 +156,13 @@
   --pt-t-fast:   0.15s cubic-bezier(0.4, 0, 0.2, 1);
   --pt-t-normal: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
   --pt-t-slow:   0.35s cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ── Container máximo — evita layouts demasiado largos em ultra-wide ── */
+  --container-max:       1600px;
+  --container-max-wide:  1920px;
+
+  /* ── Touch target mínimo (WCAG 2.5.5) ───────────────────── */
+  --touch-target: 44px;
 }
 
 /* ============================================================
@@ -166,6 +173,8 @@
 html, body {
   overscroll-behavior: none;
   overscroll-behavior-y: none;
+  /* Guarda global contra overflow horizontal */
+  overflow-x: hidden;
 }
 
 /* Oculta a scrollbar em todos os elementos no mobile.
@@ -281,10 +290,25 @@ body {
   min-height: 100dvh;
   transition: background 0.3s, color 0.3s;
   -webkit-font-smoothing: antialiased;
+  /* Safe area para dispositivos com notch/barra de navegação */
+  padding-left:   env(safe-area-inset-left);
+  padding-right:  env(safe-area-inset-right);
 }
 
 h1, h2, h3 {
   font-family: 'Playfair Display', serif;
+}
+
+/* Garante que imagens nunca causem overflow */
+img, video, svg {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* Touch targets mínimos para acessibilidade mobile */
+button, a, [role="button"], input, select, textarea {
+  min-height: var(--touch-target);
 }
 
 /* ============================================================
@@ -336,6 +360,20 @@ h1, h2, h3 {
 }
 
 /* ============================================================
+   CONTAINER — limita largura em telas ultra-wide
+   ============================================================ */
+.container {
+  width: 100%;
+  max-width: var(--container-max);
+  margin-inline: auto;
+  padding-inline: var(--space-page-x);
+}
+
+.container--wide {
+  max-width: var(--container-max-wide);
+}
+
+/* ============================================================
    PAGE HEADER
    ============================================================ */
 .page-header {
@@ -363,15 +401,36 @@ h1, h2, h3 {
 }
 
 /* ============================================================
-   RESPONSIVE — Galaxy A55 (360px), A56 (390px), iPad 9 (810px)
+   RESPONSIVE — MOBILE FIRST
+   Breakpoints: 0 / 360 / 480 / 600 / 768 / 1024 / 1280 / 1440 / 1920 / 2560
    ============================================================ */
 
-@media (max-width: 360px) {
+/* ── 0–359 px — Móveis muito pequenos ───────────────────────
+   Espaçamentos mínimos, grids de 1 coluna, fontes reduzidas   */
+@media (max-width: 359px) {
   :root {
-    --space-page-x: 12px;
-    --space-page-y: 16px;
+    --space-page-x:    12px;
+    --space-page-y:    14px;
+    --font-page-title: 16px;
+    --font-stat-val:   20px;
+    --pt-sp-4: 10px;
+    --pt-sp-6: 16px;
+    --pt-sp-8: 22px;
+  }
+  .grid-2 { grid-template-columns: 1fr; gap: 10px; }
+  .grid-3 { grid-template-columns: 1fr; gap: 10px; }
+  .page-header h2 { font-size: 16px; }
+  .page-header p  { font-size: 12px; }
+}
+
+/* ── 360–479 px — Móveis estándar (Galaxy A55, iPhone SE) ───
+   Grid 1 coluna, tipografia base, espaçamento confortável     */
+@media (min-width: 360px) and (max-width: 479px) {
+  :root {
+    --space-page-x:    14px;
+    --space-page-y:    16px;
     --font-page-title: 17px;
-    --font-stat-val: 22px;
+    --font-stat-val:   22px;
     --pt-sp-4: 12px;
     --pt-sp-6: 18px;
   }
@@ -379,32 +438,134 @@ h1, h2, h3 {
   .grid-3 { grid-template-columns: 1fr; gap: 12px; }
 }
 
-@media (min-width: 361px) and (max-width: 430px) {
+/* ── 480–599 px — Móveis grandes (iPhone Pro Max, Pixel 9) ──
+   grid-3 passa a 2 colunas; mais espaço horizontal            */
+@media (min-width: 480px) and (max-width: 599px) {
   :root {
-    --space-page-x: 14px;
-    --space-page-y: 18px;
+    --space-page-x:    16px;
+    --space-page-y:    18px;
     --font-page-title: 18px;
-    --font-stat-val: 26px;
+    --font-stat-val:   24px;
+    --pt-sp-4: 14px;
+    --pt-sp-6: 20px;
   }
   .grid-2 { grid-template-columns: 1fr; gap: 14px; }
   .grid-3 { grid-template-columns: repeat(2, 1fr); gap: 12px; }
+  .page-header h2 { font-size: 18px; }
 }
 
-@media (min-width: 768px) and (max-width: 1024px) {
+/* ── 600–767 px — Tablets pequenas / foldables ───────────────
+   Ambos os grids com 2 colunas; layout começa a abrir        */
+@media (min-width: 600px) and (max-width: 767px) {
   :root {
-    --space-page-x: 24px;
-    --space-page-y: 28px;
+    --space-page-x:    20px;
+    --space-page-y:    22px;
+    --font-page-title: 19px;
+    --font-stat-val:   26px;
+    --pt-sp-4: 14px;
+    --pt-sp-6: 22px;
+    --pt-sp-8: 28px;
+  }
+  .grid-2 { grid-template-columns: repeat(2, 1fr); gap: 16px; }
+  .grid-3 { grid-template-columns: repeat(2, 1fr); gap: 14px; }
+  .page-header h2 { font-size: 19px; }
+  .page-header p  { font-size: 13px; }
+}
+
+/* ── 768–1023 px — Tablets vertical (iPad 9ª gen, Galaxy Tab) */
+@media (min-width: 768px) and (max-width: 1023px) {
+  :root {
+    --space-page-x:    24px;
+    --space-page-y:    28px;
     --font-page-title: 22px;
-    --font-stat-val: 30px;
+    --font-stat-val:   30px;
+    --pt-sp-4: 16px;
+    --pt-sp-6: 24px;
+    --pt-sp-8: 32px;
   }
   .grid-2 { grid-template-columns: repeat(2, 1fr); gap: 20px; }
   .grid-3 { grid-template-columns: repeat(2, 1fr); gap: 18px; }
 }
 
-@media (min-width: 1025px) and (max-width: 1180px) {
+/* ── 1024–1279 px — Tablets horizontal / laptops pequenas ───  */
+@media (min-width: 1024px) and (max-width: 1279px) {
   :root {
-    --space-page-x: 28px;
-    --space-page-y: 32px;
+    --space-page-x:    28px;
+    --space-page-y:    32px;
+    --font-page-title: 23px;
+    --font-stat-val:   32px;
   }
-  .grid-3 { grid-template-columns: repeat(3, 1fr); }
+  .grid-2 { grid-template-columns: repeat(2, 1fr); gap: 22px; }
+  .grid-3 { grid-template-columns: repeat(3, 1fr); gap: 20px; }
+}
+
+/* ── 1280–1439 px — Laptops estándar ────────────────────────  */
+@media (min-width: 1280px) and (max-width: 1439px) {
+  :root {
+    --space-page-x:    32px;
+    --space-page-y:    36px;
+    --font-page-title: 24px;
+    --font-stat-val:   34px;
+    --pt-sp-8: 36px;
+    --pt-sp-10: 44px;
+  }
+  .grid-2 { grid-template-columns: repeat(2, 1fr); gap: 24px; }
+  .grid-3 { grid-template-columns: repeat(3, 1fr); gap: 22px; }
+  .page-header h2 { font-size: 26px; }
+}
+
+/* ── 1440–1919 px — Desktop grande ──────────────────────────
+   Container limitado; grid-3 pode ter 3 colunas largas       */
+@media (min-width: 1440px) and (max-width: 1919px) {
+  :root {
+    --space-page-x:    40px;
+    --space-page-y:    40px;
+    --font-page-title: 26px;
+    --font-stat-val:   36px;
+    --pt-sp-8:  40px;
+    --pt-sp-10: 52px;
+  }
+  .grid-2 { grid-template-columns: repeat(2, 1fr); gap: 28px; }
+  .grid-3 { grid-template-columns: repeat(3, 1fr); gap: 26px; }
+  .page-header {
+    margin-bottom: 36px;
+    padding-bottom: 24px;
+  }
+}
+
+/* ── 1920–2559 px — Full HD / Wide ──────────────────────────
+   Ativa container máximo para não esticar demais o layout    */
+@media (min-width: 1920px) and (max-width: 2559px) {
+  :root {
+    --space-page-x:    clamp(40px, 3vw, 64px);
+    --space-page-y:    48px;
+    --font-page-title: 28px;
+    --font-stat-val:   40px;
+    --container-max: 1760px;
+  }
+  .grid-2 { gap: 32px; }
+  .grid-3 { grid-template-columns: repeat(4, 1fr); gap: 28px; }
+  .page-header h2 { font-size: 28px; }
+  .page-header p  { font-size: 16px; }
+}
+
+/* ── 2560px+ — Ultra Wide / 2K / 4K ─────────────────────────
+   Layout centralizado com container estrito; fontes maiores   */
+@media (min-width: 2560px) {
+  :root {
+    --space-page-x:    clamp(48px, 2.5vw, 80px);
+    --space-page-y:    56px;
+    --font-page-title: clamp(28px, 1.5vw, 36px);
+    --font-stat-val:   clamp(40px, 2vw, 52px);
+    --container-max:      1920px;
+    --container-max-wide: 2200px;
+    --pt-sp-4: 20px;
+    --pt-sp-6: 30px;
+    --pt-sp-8: 48px;
+    --pt-sp-10: 64px;
+  }
+  .grid-2 { gap: 36px; }
+  .grid-3 { grid-template-columns: repeat(4, 1fr); gap: 32px; }
+  .page-header h2 { font-size: clamp(28px, 1.5vw, 36px); }
+  .page-header p  { font-size: clamp(15px, 0.8vw, 18px); }
 }


### PR DESCRIPTION
## Descrição

Implementa cobertura responsiva completa no `App.css`, cobrindo todos os breakpoints em falta.

## Breakpoints adicionados

| Breakpoint | Intervalo |
|---|---|
| Móveis grandes | 480–599px |
| Foldables / tablets pequenas | 600–767px |
| Laptops standard | 1280–1439px |
| Desktop grande | 1440–1919px |
| Full HD / Wide | 1920–2559px |
| Ultra Wide / 2K / 4K | 2560px+ |

## Melhorias globais

- `overflow-x: hidden` em html/body
- `env(safe-area-inset-*)` para notch/barra Android/iOS
- Touch targets mínimos 44px (WCAG 2.5.5)
- `max-width: 100%` em img/video/svg
- Classes utilitárias `.container` e `.container--wide`