### PR TITLE
fix: corregir problemas de scroll en mobile y desktop

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -166,30 +166,32 @@
 }
 
 /* ============================================================
-   SCROLL — ocultar scrollbar em mobile sem bloquear conteúdo
+   SCROLL — ocultar scrollbar en mobile sin bloquear contenido
    ============================================================ */
 
-/* Evita bounce/pull-to-refresh e scroll lateral indesejado */
+/* FIX: overflow-x:hidden en html/body puede bloquear el scroll
+   vertical en iOS Safari. Se reemplaza por overflow-x:clip que
+   corta el desbordamiento horizontal sin crear un nuevo contexto
+   de scroll que interfiera con el vertical. */
 html, body {
   overscroll-behavior: none;
   overscroll-behavior-y: none;
-  /* Guarda global contra overflow horizontal */
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
-/* Oculta a scrollbar em todos os elementos no mobile.
-   O scroll CONTINUA funcionando — só a barra some visualmente. */
+/* Oculta la scrollbar en todos los elementos en mobile.
+   El scroll SIGUE funcionando — solo la barra desaparece visualmente. */
 @media (max-width: 1024px) {
   * {
-    scrollbar-width: none;       /* Firefox */
-    -ms-overflow-style: none;    /* IE / Edge legado */
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
   *::-webkit-scrollbar {
-    display: none;               /* Chrome / Samsung Internet / Safari */
+    display: none;
   }
 }
 
-/* Desktop: mantém scrollbar discreta */
+/* Desktop: mantiene scrollbar discreta */
 @media (min-width: 1025px) {
   ::-webkit-scrollbar         { width: 5px; height: 5px; }
   ::-webkit-scrollbar-thumb   { background: var(--warm); border-radius: 3px; }
@@ -290,7 +292,6 @@ body {
   min-height: 100dvh;
   transition: background 0.3s, color 0.3s;
   -webkit-font-smoothing: antialiased;
-  /* Safe area para dispositivos com notch/barra de navegação */
   padding-left:   env(safe-area-inset-left);
   padding-right:  env(safe-area-inset-right);
 }
@@ -299,14 +300,12 @@ h1, h2, h3 {
   font-family: 'Playfair Display', serif;
 }
 
-/* Garante que imagens nunca causem overflow */
 img, video, svg {
   max-width: 100%;
   height: auto;
   display: block;
 }
 
-/* Touch targets mínimos para acessibilidade mobile */
 button, a, [role="button"], input, select, textarea {
   min-height: var(--touch-target);
 }
@@ -405,8 +404,6 @@ button, a, [role="button"], input, select, textarea {
    Breakpoints: 0 / 360 / 480 / 600 / 768 / 1024 / 1280 / 1440 / 1920 / 2560
    ============================================================ */
 
-/* ── 0–359 px — Móveis muito pequenos ───────────────────────
-   Espaçamentos mínimos, grids de 1 coluna, fontes reduzidas   */
 @media (max-width: 359px) {
   :root {
     --space-page-x:    12px;
@@ -423,8 +420,6 @@ button, a, [role="button"], input, select, textarea {
   .page-header p  { font-size: 12px; }
 }
 
-/* ── 360–479 px — Móveis estándar (Galaxy A55, iPhone SE) ───
-   Grid 1 coluna, tipografia base, espaçamento confortável     */
 @media (min-width: 360px) and (max-width: 479px) {
   :root {
     --space-page-x:    14px;
@@ -438,8 +433,6 @@ button, a, [role="button"], input, select, textarea {
   .grid-3 { grid-template-columns: 1fr; gap: 12px; }
 }
 
-/* ── 480–599 px — Móveis grandes (iPhone Pro Max, Pixel 9) ──
-   grid-3 passa a 2 colunas; mais espaço horizontal            */
 @media (min-width: 480px) and (max-width: 599px) {
   :root {
     --space-page-x:    16px;
@@ -454,8 +447,6 @@ button, a, [role="button"], input, select, textarea {
   .page-header h2 { font-size: 18px; }
 }
 
-/* ── 600–767 px — Tablets pequenas / foldables ───────────────
-   Ambos os grids com 2 colunas; layout começa a abrir        */
 @media (min-width: 600px) and (max-width: 767px) {
   :root {
     --space-page-x:    20px;
@@ -472,7 +463,6 @@ button, a, [role="button"], input, select, textarea {
   .page-header p  { font-size: 13px; }
 }
 
-/* ── 768–1023 px — Tablets vertical (iPad 9ª gen, Galaxy Tab) */
 @media (min-width: 768px) and (max-width: 1023px) {
   :root {
     --space-page-x:    24px;
@@ -487,7 +477,6 @@ button, a, [role="button"], input, select, textarea {
   .grid-3 { grid-template-columns: repeat(2, 1fr); gap: 18px; }
 }
 
-/* ── 1024–1279 px — Tablets horizontal / laptops pequenas ───  */
 @media (min-width: 1024px) and (max-width: 1279px) {
   :root {
     --space-page-x:    28px;
@@ -499,7 +488,6 @@ button, a, [role="button"], input, select, textarea {
   .grid-3 { grid-template-columns: repeat(3, 1fr); gap: 20px; }
 }
 
-/* ── 1280–1439 px — Laptops estándar ────────────────────────  */
 @media (min-width: 1280px) and (max-width: 1439px) {
   :root {
     --space-page-x:    32px;
@@ -514,8 +502,6 @@ button, a, [role="button"], input, select, textarea {
   .page-header h2 { font-size: 26px; }
 }
 
-/* ── 1440–1919 px — Desktop grande ──────────────────────────
-   Container limitado; grid-3 pode ter 3 colunas largas       */
 @media (min-width: 1440px) and (max-width: 1919px) {
   :root {
     --space-page-x:    40px;
@@ -533,8 +519,6 @@ button, a, [role="button"], input, select, textarea {
   }
 }
 
-/* ── 1920–2559 px — Full HD / Wide ──────────────────────────
-   Ativa container máximo para não esticar demais o layout    */
 @media (min-width: 1920px) and (max-width: 2559px) {
   :root {
     --space-page-x:    clamp(40px, 3vw, 64px);
@@ -549,8 +533,6 @@ button, a, [role="button"], input, select, textarea {
   .page-header p  { font-size: 16px; }
 }
 
-/* ── 2560px+ — Ultra Wide / 2K / 4K ─────────────────────────
-   Layout centralizado com container estrito; fontes maiores   */
 @media (min-width: 2560px) {
   :root {
     --space-page-x:    clamp(48px, 2.5vw, 80px);

--- a/src/components/layout/PatientLayout.css
+++ b/src/components/layout/PatientLayout.css
@@ -7,9 +7,11 @@
 /* ── Contenedor raíz ────────────────────────────────────────── */
 .patient-layout {
   display: flex;
-  min-height: 100dvh;
+  /* FIX: mismo patrón que TherapistLayout —
+     height fija + overflow:clip para scroll vertical libre. */
+  height: 100dvh;
+  overflow: clip;
   background: var(--cream);
-  overflow: hidden;
 }
 
 /* ════════════════════════════════════════════════════════════
@@ -20,9 +22,11 @@
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  min-height: 100dvh;
+  /* FIX: height:100% en lugar de min-height:100dvh */
+  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding:

--- a/src/components/layout/TherapistLayout.css
+++ b/src/components/layout/TherapistLayout.css
@@ -15,9 +15,12 @@
 /* ── Contenedor raíz ────────────────────────────────────────── */
 .therapist-layout {
   display: flex;
-  min-height: 100dvh;        /* dvh: iOS Safari barra dinámica */
+  /* FIX: height fija + overflow:hidden en el root crea el único
+     contexto de scroll; overflow:clip (no overflow:hidden) evita
+     que el contenedor robe el scroll del hijo __main. */
+  height: 100dvh;
+  overflow: clip;            /* bloquea scroll lateral sin atrapar el vertical */
   background: var(--cream);
-  overflow: hidden;
 }
 
 /* ════════════════════════════════════════════════════════════
@@ -29,9 +32,14 @@
   width: 100%;
   min-width: 0;              /* evita overflow en flex child */
   box-sizing: border-box;
-  min-height: 100dvh;
+  /* FIX: min-height eliminado — el flex ocupa 100dvh del padre.
+     height:100% + overflow-y:auto es el patrón correcto para
+     un área scrolleable dentro de un contenedor flex fijo. */
+  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+  /* FIX: scroll con inercia nativa en iOS (Safari lo ignora sin esto) */
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding:
@@ -130,7 +138,6 @@
   .therapist-layout__main {
     margin-left: var(--sb-width-full);
     padding: 36px clamp(32px, 4vw, 64px);
-    /* Limita el ancho del contenido para mejor legibilidad */
     max-width: calc(1400px + var(--sb-width-full));
   }
 }
@@ -149,7 +156,6 @@
   .therapist-layout__main {
     margin-left: var(--sb-width-full);
     padding: 48px clamp(64px, 6vw, 120px);
-    /* Centra el contenido en pantallas ultrawide */
     max-width: calc(1800px + var(--sb-width-full));
     margin-right: auto;
   }
@@ -220,7 +226,6 @@
    ════════════════════════════════════════════════════════════ */
 .floating-bell {
   position: fixed;
-  /* safe-area-inset-top evita solapamiento con notch/Dynamic Island */
   top: calc(14px + env(safe-area-inset-top, 0px));
   right: calc(14px + env(safe-area-inset-right, 0px));
   z-index: var(--z-fab);
@@ -235,12 +240,10 @@
   -webkit-backdrop-filter: blur(8px);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
   transition: background 0.25s, transform 0.2s;
-  /* Área táctil mínima 44px garantizada */
   min-width: 44px;
   min-height: 44px;
 }
 
-/* En móviles muy pequeños, ligeramente más compacto */
 @media (max-width: 359px) {
   .floating-bell {
     width: 44px;
@@ -302,7 +305,6 @@
   border-radius: 50%;
   transition: background 0.2s;
   color: inherit;
-  /* Área táctil mínima 44px en tablet */
   min-width: 44px;
   min-height: 44px;
 }
@@ -360,7 +362,6 @@
 
 .logout-modal__btn {
   flex: 1;
-  /* Altura mínima de 44px para área táctil cómoda en móvil */
   height: clamp(44px, 6vw, 48px);
   border-radius: 10px;
   font-size: clamp(0.85rem, 2.5vw, 0.95rem); font-weight: 600;
@@ -374,7 +375,6 @@
 .logout-modal__btn--confirm       { background: #e53e3e; color: #fff; box-shadow: 0 4px 12px rgba(229,62,62,0.3); }
 .logout-modal__btn--confirm:hover { background: #c53030; }
 
-/* Móviles muy pequeños: botones apilados */
 @media (max-width: 359px) {
   .logout-modal { padding: 20px 14px 16px; }
   .logout-modal__actions { flex-direction: column; }


### PR DESCRIPTION
## Problema
Usuarios reportaban imposibilidad de hacer scroll en las vistas del layout (tanto terapeuta como paciente), especialmente en mobile.

## Causa raíz
Tres bugs combinados causaban el bloqueo de scroll:

1. **`overflow: hidden` en el contenedor raíz** — `.therapist-layout` y `.patient-layout` tenían `overflow: hidden`, lo cual en un flex container con altura fija absorbe el scroll del hijo.

2. **`min-height: 100dvh` en `__main`** — el hijo scrolleable tenía `min-height: 100dvh` en lugar de `height: 100%`, haciendo que el elemento creciera fuera del contenedor sin scroll propio.

3. **`overflow-x: hidden` en `html, body`** — en iOS Safari crea un contexto de scroll que interfiere con el scroll vertical de los hijos.

## Fixes
- `overflow: hidden` → `overflow: clip` en contenedores raíz
- `min-height: 100dvh` → `height: 100%` en `__main`
- Añadido `-webkit-overflow-scrolling: touch` para inercia nativa en iOS
- `overflow-x: hidden` → `overflow-x: clip` en `html, body`